### PR TITLE
fix(storage): 修正 Database 上 get 方法对不含 where 字段 query 的处理

### DIFF
--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -445,7 +445,7 @@ export class Database {
         mainTable: table!
       }
       const { limit, skip } = clause
-      const provider = new PredicateProvider(table!, clause.where!)
+      const provider = new PredicateProvider(table!, clause.where)
 
       return new Selector<T>(db, query, matcher, provider, limit, skip, orderDesc)
     })

--- a/src/storage/modules/PredicateProvider.ts
+++ b/src/storage/modules/PredicateProvider.ts
@@ -71,11 +71,11 @@ export class PredicateProvider<T> {
 
   constructor(
     private table: lf.schema.Table,
-    private meta: Predicate<T>
+    private meta?: Predicate<T>
   ) { }
 
   getPredicate(): lf.Predicate | null {
-    const predicates = this.normalizeMeta(this.meta)
+    const predicates = this.meta ? this.normalizeMeta(this.meta) : []
     if (predicates.length) {
       if (predicates.length === 1) {
         return predicates[0]

--- a/test/specs/storage/modules/Selector.spec.ts
+++ b/test/specs/storage/modules/Selector.spec.ts
@@ -153,7 +153,7 @@ export default describe('Selector test', () => {
 
     const sql = selector.toString()
 
-    expect(sql).to.equal('SELECT * FROM TestSelectMetadata WHERE ((TestSelectMetadata.time > 50));')
+    expect(sql).to.equal('SELECT * FROM TestSelectMetadata WHERE (TestSelectMetadata.time > 50);')
   })
 
   it('should get correct results with orderBy', function* () {
@@ -922,6 +922,26 @@ export default describe('Selector test', () => {
         .do(r => expect(r[75].name).equal(update3))
     })
 
+    it('concat selector should ok when neither selectors have predicateProvider', function* () {
+      selector1 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 0
+      )
+      selector2 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 20
+      )
+      const result = yield selector1.concat(selector2).values()
+      expect(result).to.have.lengthOf(40)
+      result.forEach((r: any, index: number) => {
+        expect(r).to.deep.equal(storeData[index])
+      })
+    })
+
     it('concat selector should ok with OrderDescription', function* () {
       const selector6 = new Selector(db,
         db.select().from(table),
@@ -1010,6 +1030,42 @@ export default describe('Selector test', () => {
       const error = TokenConcatFailed()
 
       expect(fn).to.throw(error.message)
+    })
+
+    it('concat two selector with one of the them not having a predicateProvider should throw with correct error message', () => {
+      const selector6 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 0
+      )
+      const selector7 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        new PredicateProvider(table, { time: { $gte: 50 } }),
+        20, 20
+      )
+
+      const selector6_1 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        new PredicateProvider(table, { time: { $gt: 50 } }),
+        20, 0
+      )
+      const selector7_1 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 20
+      )
+
+      const error = TokenConcatFailed()
+
+      const fn = () => selector6.concat(selector7)
+      expect(fn).to.throw(error.message)
+
+      const fn_1 = () => selector6_1.concat(selector7_1)
+      expect(fn_1).to.throw(error.message)
     })
 
     it('concat two selector select not match should throw', () => {


### PR DESCRIPTION
...并在 concat selector 时进行的查询信息等价比较上，妥善处理 predicateProvider 为空而导致没有 toString 方法可调用，throw 的情况。

### Note:

当前在 Selector concat 时，我们会验证两个 query 里的 PredicateProvider（由输入的 where 字段生成） 是否等价。办法是调用各自 PredicateProvider 的 toString 方法，看生成的字符串是否一样。

但 @Miloas 之前在应用开发中遇到了报错“没有 toString 方法”的情况。此例中，输入的 query 没有 where 字段，故生成的 PredicateProvider 是 null，不能在其上直接调用 toString。不带 where 的 query 是完全合理的，我们不应该报错。

**记录一下自己对外部传入 query 的 where 字段为空这个情况的看法：**

传入 query 的 where 字段为空的话，处理上是不应该遇到任何阻碍的。也就是说，代码中，整个路径上，不应该假设需要这个字段。...直至 where 被转换成 PredicateProvider。

现在一个**需要明确**的问题是，下面两种情况，在语义上的**区别**：

 - 传给 Selector 构造函数的 predicateProvider 参数为空
 - predicateProvider.getPredicate() 得空

根据目前的实现，和我自己的理解，前者应该代表传入 query 不带 where 字段，而后者代表传入 query 所带 where 字段解析出错。