### PR TITLE
fix(Selector): prevent the LfIssueFix from skipping valid update

### DIFF
--- a/test/specs/storage/modules/Selector.spec.ts
+++ b/test/specs/storage/modules/Selector.spec.ts
@@ -31,7 +31,7 @@ export default describe('Selector test', () => {
   let storeData: any[]
   let subscription: Subscription
 
-  beforeEach(function * () {
+  const constructDBAndATable = () => {
     const schemaBuilder = lf.schema.create('SelectorTest', version ++)
     const db$ = lfFactory(schemaBuilder, {
       storeType: DataStoreType.MEMORY,
@@ -47,9 +47,16 @@ export default describe('Selector test', () => {
 
     db$.connect()
 
-    yield db$.do(r => {
-      db = r
-      table = db.getSchema().table('TestSelectMetadata')
+    return db$.map((testDB) => ({
+      db: testDB,
+      table: testDB.getSchema().table('TestSelectMetadata')
+    }))
+  }
+
+  beforeEach(function * () {
+    yield constructDBAndATable().do((r) => {
+      db = r.db
+      table = r.table
     })
 
     const rows: lf.Row[] = []
@@ -203,6 +210,43 @@ export default describe('Selector test', () => {
         .set(table['name'], newName)
         .where(table['_id'].eq('_id:50'))
         .exec()
+    })
+
+    it('observe asynchronous insertions completely', function* () {
+      yield constructDBAndATable().do((r) => {
+        db = r.db
+        table = r.table // ensure empty table
+      })
+
+      const n = 3
+      const rows = [
+        { _id: '_id:939.1', name: 'name:939.1', time: 939.1, priority: 10 },
+        { _id: '_id:939.2', name: 'name:939.2', time: 939.2, priority: 20 },
+        { _id: '_id:939.3', name: 'name:939.3', time: 939.3, priority: 30 }
+      ]
+      const insertRow = (i: number) =>
+        db.insert().into(table).values([table.createRow(rows[i])]).exec()
+
+      const count$ = Observable.range(0, n + 1)
+
+      const insert$ = Observable.concat(
+        Observable.of({}).subscribeOn(Scheduler.asap),
+        Observable.defer(() => insertRow(0)).subscribeOn(Scheduler.asap),
+        Observable.defer(() => insertRow(1)).subscribeOn(Scheduler.asap),
+        Observable.defer(() => insertRow(2)).subscribeOn(Scheduler.asap)
+      )
+
+      const change$ = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        new PredicateProvider(table, {}),
+      ).changes()
+
+      yield Observable.zip(count$, insert$, change$,
+        (nth, _, result) => {
+          expect(result).to.deep.equal(rows.slice(0, nth))
+        }
+      )
     })
 
     it('should observe deletion of the only row in db', function* () {


### PR DESCRIPTION
<s>尚未重现实际使用中遇到的问题，需要进一步确定用户代码中的问题是怎么构造的，再补充测试，并修复问题。</s>

...by mistake.

先前我们没有准确实现“第一次和第二次在它们的值不为空的时候是重复的”的相应判断逻辑，没有检查第一次的值是否为空。

这个错误纠正后，原先的过滤 lf 重复推送的效果依然保持，并添加了测试，确保不会过滤掉不该过滤的推送。

并简化了代码。

...to resolve #27