### PR TITLE
issue(tools): 调长 watch 脚本中的 debounceTime，适应 ts2.6 新 watch

### DIFF
--- a/tools/watch.ts
+++ b/tools/watch.ts
@@ -14,7 +14,7 @@ function watch (paths: string[]) {
         })
       })
     })
-    .debounceTime(300)
+    .debounceTime(500)
 }
 
 watch(['spec-js'])


### PR DESCRIPTION
...降低 tsc 新 watch mode 导致的“重新编译已完成”的误判概率，避免
runTman 在重新编译尚未完成，而文件更新正在持续输出的情况下，被多次调用，
导致某些测试失败。