### PR TITLE
fix(QueryToken): 修复 combine() 误用 Selector.prototype.concat 的问题

### DIFF
--- a/src/storage/modules/QueryToken.ts
+++ b/src/storage/modules/QueryToken.ts
@@ -76,7 +76,7 @@ export class QueryToken<T> {
       combineAll<Observable<Selector<T>>, Selector<T>[]>(),
       map((r) => {
         const first = r.shift()
-        return first!.concat(...r)
+        return first!.combine(...r)
       })
     )
     return new QueryToken<T>(newSelector$)

--- a/test/specs/storage/modules/QueryToken.spec.ts
+++ b/test/specs/storage/modules/QueryToken.spec.ts
@@ -101,6 +101,9 @@ export default describe('QueryToken Testcase', () => {
         mockSelector2 = new MockSelector(generateMockTestdata(tasks2))
         queryToken2 = new QueryToken(Observable.of(mockSelector2) as any)
         combined = queryToken.combine(queryToken2)
+        combined.selector$.subscribe((mock) => {
+          expect(mock['__test_label_selector_kind__']).to.equal('by combine')
+        })
       })
 
       it('should get a new QueryToken', () => {
@@ -169,6 +172,9 @@ export default describe('QueryToken Testcase', () => {
         mockSelector2 = new MockSelector(generateMockTestdata(tasks2))
         queryToken2 = new QueryToken(Observable.of(mockSelector2) as any)
         concated = queryToken.concat(queryToken2)
+        concated.selector$.subscribe((mock) => {
+          expect(mock['__test_label_selector_kind__']).to.equal('by concat')
+        })
       })
 
       it('should get new QueryToken', () => {

--- a/test/utils/mocks/Selector.ts
+++ b/test/utils/mocks/Selector.ts
@@ -43,7 +43,11 @@ export class MockSelector<T> {
     return this.mapFn(this.change$.take(1))
   }
 
-  concat = this.combine
+  concat(... metas: MockSelector<T>[]) {
+    const dist = this.combine(...metas)
+    dist['__test_label_selector_kind__'] = 'by concat'
+    return dist
+  }
 
   combine(... metas: MockSelector<T>[]) {
     metas.unshift(this)
@@ -60,6 +64,7 @@ export class MockSelector<T> {
         .combineAll()
         .map((r: T[][]) => r.reduce((acc, val) => acc.concat(val)))
     }
+    dist['__test_label_selector_kind__'] = 'by combine'
     return dist
   }
 


### PR DESCRIPTION
...在先前的代码重构中，错在 QueryToken.prototype.combine 里使用了
Selector 的 concat 方法而不是 combine 方法。这里做了纠正，并为相关测试
代码做了完善：

...QueryToken 的测试使用 MockSelector 而不是 Selector，而原来
MockSelector 从其 concat 或 combine 获得的结果是无法区分的；现在在它们
的返回值上添加额外信息，便于测试代码区分当前使用的 MockSelector 对象是
来自 concat 还是 combine。