### PR TITLE
fix(assert): use lazily evaluated exception producer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactivedb",
-  "version": "0.9.16",
+  "version": "0.9.17-alpha.1-lazyexception",
   "description": "Reactive ORM for Lovefield",
   "main": "dist/cjs/index.js",
   "scripts": {

--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -40,7 +40,7 @@ export class Database {
 
   private findSchema = (name: string): ParsedSchema => {
     const schema = this.schemas.get(name)
-    assert(schema, Exception.NonExistentTable(name))
+    assert(schema, () => Exception.NonExistentTable(name))
     return schema!
   }
 
@@ -50,11 +50,11 @@ export class Database {
    */
   defineSchema<T>(tableName: string, schema: SchemaDef<T>) {
     const advanced = !this.schemaDefs.has(tableName) && !this.connected
-    assert(advanced, Exception.UnmodifiableTable())
+    assert(advanced, () => Exception.UnmodifiableTable())
 
     const hasPK = Object.keys(schema)
       .some((key: string) => schema[key].primaryKey === true)
-    assert(hasPK, Exception.PrimaryKeyNotProvided())
+    assert(hasPK, () => Exception.PrimaryKeyNotProvided())
 
     this.schemaDefs.set(tableName, schema)
     return this
@@ -90,7 +90,7 @@ export class Database {
   }
 
   load(data: any) {
-    assert(!this.connected, Exception.DatabaseIsNotEmpty())
+    assert(!this.connected, () => Exception.DatabaseIsNotEmpty())
 
     return this.database$
       .concatMap(db => {
@@ -356,7 +356,7 @@ export class Database {
         columns.set(key, def.type as RDBType)
 
         if (def.primaryKey) {
-          assert(!primaryKey[0], Exception.PrimaryKeyConflict())
+          assert(!primaryKey[0], () => Exception.PrimaryKeyConflict())
           primaryKey.push(key)
         }
 
@@ -519,7 +519,7 @@ export class Database {
 
     const onlyNavigator = Array.from(fieldsValue.keys())
       .every(key => contains(key, navigators))
-    assert(!onlyNavigator, Exception.InvalidQuery())
+    assert(!onlyNavigator, () => Exception.InvalidQuery())
 
     if (!hasKey) {
       // 保证主键一定比关联字段更早的被遍历到
@@ -539,7 +539,7 @@ export class Database {
       }
 
       columns.push(...ret.columns)
-      assert(!rootDefinition[key], Exception.AliasConflict(key, tableName))
+      assert(!rootDefinition[key], () => Exception.AliasConflict(key, tableName))
 
       if ((defs as ColumnDef).column) {
         rootDefinition[key] = defs
@@ -631,7 +631,7 @@ export class Database {
     const schema = this.findSchema(tableName)
     const pk = schema.pk
     const pkVal = compoundEntites[pk]
-    assert(pkVal !== undefined, Exception.PrimaryKeyNotProvided())
+    assert(pkVal !== undefined, () => Exception.PrimaryKeyNotProvided())
 
     const [ table ] = Database.getTables(db, tableName)
     const identifier = fieldIdentifier(tableName, pkVal)

--- a/src/storage/modules/Mutation.ts
+++ b/src/storage/modules/Mutation.ts
@@ -67,7 +67,7 @@ export class Mutation {
   }
 
   private toUpdater() {
-    assert(this.meta, Exception.PrimaryKeyNotProvided())
+    assert(this.meta, () => Exception.PrimaryKeyNotProvided())
 
     const query = this.db.update(this.table)
     query.where(this.table[this.meta.key].eq(this.meta.val))
@@ -85,7 +85,7 @@ export class Mutation {
   }
 
   private toRow() {
-    assert(this.meta, Exception.PrimaryKeyNotProvided())
+    assert(this.meta, () => Exception.PrimaryKeyNotProvided())
 
     return {
       table: this.table,

--- a/src/storage/modules/QueryToken.ts
+++ b/src/storage/modules/QueryToken.ts
@@ -23,7 +23,7 @@ export class QueryToken<T> {
   }
 
   values(): Observable<T[]> {
-    assert(!this.consumed, TokenConsumed())
+    assert(!this.consumed, () => TokenConsumed())
 
     this.consumed = true
     return (this.selector$ as Observable<Selector<T>>)
@@ -32,7 +32,7 @@ export class QueryToken<T> {
   }
 
   changes(): Observable<T[]> {
-    assert(!this.consumed, TokenConsumed())
+    assert(!this.consumed, () => TokenConsumed())
 
     this.consumed = true
     return (this.selector$ as Observable<Selector<T>>)

--- a/src/storage/modules/Selector.ts
+++ b/src/storage/modules/Selector.ts
@@ -19,7 +19,7 @@ export class Selector <T> {
     const [ minSkip ] = skipsAndLimits
     const maxLimit = skipsAndLimits.reduce((acc, current) => {
       const nextSkip = acc.skip! + acc.limit!
-      assert(current.skip === nextSkip, Exception.TokenConcatFailed(`
+      assert(current.skip === nextSkip, () => Exception.TokenConcatFailed(`
         skip should be serial,
         expect: ${JSON.stringify(acc, null, 2)}
         actual: ${nextSkip}
@@ -46,7 +46,7 @@ export class Selector <T> {
       .publishReplay(1)
       .refCount()
     dist.values = () => {
-      assert(!dist.consumed, Exception.TokenConsumed())
+      assert(!dist.consumed, () => Exception.TokenConsumed())
       dist.consumed = true
       return Observable.from(metaDatas)
         .flatMap(metaData => metaData.values())
@@ -213,7 +213,7 @@ export class Selector <T> {
         )
       )
     )
-    assert(equal, Exception.TokenConcatFailed())
+    assert(equal, () => Exception.TokenConcatFailed())
 
     return Selector.concatFactory(this, ...selectors)
   }

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,7 +1,9 @@
-export function assert(condition: any, error: Error | string) {
+export function assert(condition: any, produceError: () => Error | string) {
   if (condition) {
     return
   }
+
+  const error = produceError()
 
   if (error instanceof Error) {
     throw error

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.9.16'
+export default '0.9.17-alpha.1-lazyexception'

--- a/test/specs/utils/utils.spec.ts
+++ b/test/specs/utils/utils.spec.ts
@@ -381,17 +381,17 @@ export default describe('Utils Testcase: ', () => {
   describe('Func: assert', () => {
 
     it('should throw when assert failed [1]', () => {
-      const check = () => assert(false, Error('failed'))
+      const check = () => assert(false, () => Error('failed'))
       expect(check).to.throw('failed')
     })
 
     it('should throw when assert failed [2]', () => {
-      const check = () => assert(false, 'failed')
+      const check = () => assert(false, () => 'failed')
       expect(check).to.throw('failed')
     })
 
     it('should not throw when assert successed', () => {
-      const check = () => assert(true, Error('error code path'))
+      const check = () => assert(true, () => Error('error code path'))
       expect(check).to.not.throw()
     })
 


### PR DESCRIPTION
...to prevent exception from being unnecessarily created when the
assertion is truthy.