### PR TITLE
WIP:  fix(typing/Predicate): 修复 Predicate 类型

### DIFF
--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -171,14 +171,14 @@ export class Database {
     return this.database$.pipe(concatMap(insert))
   }
 
-  get<T>(tableName: string, query: Query<T> = {}, mode: JoinMode = JoinMode.imlicit): QueryToken<T> {
+  get<T = any>(tableName: string, query: Query<T> = {}, mode: JoinMode = JoinMode.imlicit): QueryToken<T> {
     const selector$ = this.database$.pipe(
       map(db => this.buildSelector(db, tableName, query, mode))
     )
     return new QueryToken<T>(selector$)
   }
 
-  update<T>(tableName: string, clause: Predicate<T>, raw: Partial<T>): Observable<ExecutorResult> {
+  update<T = any>(tableName: string, clause: Predicate<T>, raw: Partial<T>): Observable<ExecutorResult> {
     const type = getType(raw)
     if (type !== 'Object') {
       return Observable.throw(Exception.InvalidType(['Object', type]))
@@ -226,7 +226,7 @@ export class Database {
     return this.database$.pipe(concatMap(update))
   }
 
-  delete<T>(tableName: string, clause: Predicate<T> = {}): Observable<ExecutorResult> {
+  delete<T = any>(tableName: string, clause: Predicate<T> = {}): Observable<ExecutorResult> {
     const [ pk, err ] = tryCatch<string>(this.findPrimaryKey)(tableName)
     if (err) {
       return Observable.throw(err)
@@ -266,13 +266,13 @@ export class Database {
     return this.database$.pipe(concatMap(deletion))
   }
 
-  upsert<T>(tableName: string, raw: T): Observable<ExecutorResult>
+  upsert<T = any>(tableName: string, raw: T): Observable<ExecutorResult>
 
-  upsert<T>(tableName: string, raw: T[]): Observable<ExecutorResult>
+  upsert<T = any>(tableName: string, raw: T[]): Observable<ExecutorResult>
 
-  upsert<T>(tableName: string, raw: T | T[]): Observable<ExecutorResult>
+  upsert<T = any>(tableName: string, raw: T | T[]): Observable<ExecutorResult>
 
-  upsert<T>(tableName: string, raw: T | T[]): Observable<ExecutorResult> {
+  upsert<T = any>(tableName: string, raw: T | T[]): Observable<ExecutorResult> {
     const upsert = (db: lf.Database) => {
       const sharing = new Map<any, Mutation>()
       const insert: Mutation[] = []
@@ -297,7 +297,7 @@ export class Database {
     return this.database$.pipe(concatMap(upsert))
   }
 
-  remove<T>(tableName: string, clause: Clause<T> = {}): Observable<ExecutorResult> {
+  remove<T = any>(tableName: string, clause: Clause<T> = {}): Observable<ExecutorResult> {
     const [schema, err] = tryCatch<ParsedSchema>(this.findSchema)(tableName)
     if (err) {
       return Observable.throw(err)
@@ -571,7 +571,7 @@ export class Database {
       mainTable: table!
     }
     const { limit, skip } = clause
-    const provider = new PredicateProvider(table!, clause.where)
+    const provider = new PredicateProvider<T>(table!, clause.where)
 
     return new Selector<T>(db, query, matcher, provider, limit, skip, orderDesc)
   }
@@ -852,7 +852,9 @@ export class Database {
         entities.forEach(entity => {
           const pkVal = entity[pk]
           const clause = createPkClause(pk, pkVal)
-          const predicate = createPredicate(table, clause)
+          // todo(dingwen): 调查是该用 clause 还是 clause.where，
+          // 可以确定的是，clause 是带 where 的。
+          const predicate = createPredicate(table, clause.where)
           const query = predicatableQuery(db, table, predicate!, StatementType.Delete)
 
           queryCollection.push(query)

--- a/test/schemas/Project.ts
+++ b/test/schemas/Project.ts
@@ -4,7 +4,7 @@ export interface ProjectSchema {
   _id: TeambitionTypes.ProjectId
   name: string
   isArchived: boolean
-  posts: any[]
+  posts: any
 }
 export default (db: Database) => db.defineSchema<ProjectSchema>('Project', {
   _id: {
@@ -21,7 +21,7 @@ export default (db: Database) => db.defineSchema<ProjectSchema>('Project', {
     type: Relationship.oneToMany,
     virtual: {
       name: 'Post',
-      where: ref => ({
+      where: (ref) => ({
         _id: ref.belongTo
       })
     }

--- a/test/schemas/Test.ts
+++ b/test/schemas/Test.ts
@@ -1,41 +1,9 @@
-import { TeambitionTypes, Database, RDBType, Relationship } from '../index'
+import { TeambitionTypes, Database, RDBType } from '../index'
 
 export interface TestSchema {
   _id: string
   name: string
   taskId: TeambitionTypes.TaskId
-}
-
-export const TestFixture = (db: Database) => {
-  const schema = {
-    _id: {
-      type: RDBType.STRING,
-      primaryKey: true
-    },
-    data1: {
-      type: RDBType.ARRAY_BUFFER,
-    },
-    data2: {
-      type: RDBType.NUMBER
-    },
-    data3: {
-      type: RDBType.STRING,
-      virtual: {
-        name: 'Project',
-        where: (ref: any) => ({
-          _projectId: ref._id
-        })
-      }
-    },
-    data4: {
-      type: RDBType.OBJECT
-    },
-    data5: {
-      type: RDBType.INTEGER
-    }
-  }
-
-  db.defineSchema('Fixture1', schema)
 }
 
 export const TestFixture2 = (db: Database) => {
@@ -66,27 +34,4 @@ export const TestFixture2 = (db: Database) => {
   }
 
   return db.defineSchema('Fixture2', schema)
-}
-
-export const TestFixture3 = (db: Database) => {
-  const schema = {
-    id: {
-      type: RDBType.STRING,
-      primaryKey: true
-    },
-    data1: {
-      type: RDBType.NUMBER
-    },
-    data2: {
-      type: Relationship.oneToMany,
-      virtual: {
-        name: 'Project',
-        where: (ref: any) => ({
-          id: ref['_id']
-        })
-      }
-    }
-  }
-
-  return db.defineSchema('Test', schema)
 }

--- a/test/schemas/index.ts
+++ b/test/schemas/index.ts
@@ -25,7 +25,7 @@ export { TaskSchema } from './Task'
 export { ProgramSchema } from './Program'
 export { ModuleSchema } from './Module'
 export { EngineerSchema } from './Engineer'
-export { TestSchema, TestFixture, TestFixture2 } from './Test'
+export { TestSchema, TestFixture2 } from './Test'
 
 /**
  * import ActivitySelectMeta from './Activity'

--- a/test/specs/storage/Database.public.spec.ts
+++ b/test/specs/storage/Database.public.spec.ts
@@ -610,7 +610,7 @@ export default describe('Database Testcase: ', () => {
 
     it('shouldn\'t to update column which is defined as primarykey', function* () {
       const note = 'foo'
-      yield database.update('Task', target._id as string, {
+      yield database.update('Task', target._id as any, {
         _id: 'bar',
         note
       })
@@ -652,7 +652,7 @@ export default describe('Database Testcase: ', () => {
       const u1 = uuid()
       const u2 = uuid()
 
-      yield database.update('Task', clause, {
+      yield database.update<TaskSchema>('Task', clause, {
         _stageId: u1
       })
 
@@ -662,7 +662,7 @@ export default describe('Database Testcase: ', () => {
         }
       }).values()
 
-      yield database.update('Task', clause, {
+      yield database.update<TaskSchema>('Task', clause, {
         _stageId: u2
       })
 
@@ -678,7 +678,7 @@ export default describe('Database Testcase: ', () => {
 
     it('should be able to update property which is stored as hidden column', function* () {
       const newCreated = new Date(2017, 1, 1)
-      yield database.update('Task', {
+      yield database.update<TaskSchema>('Task', {
         _id: target._id
       }, {
         created: newCreated.toISOString()
@@ -760,7 +760,7 @@ export default describe('Database Testcase: ', () => {
       const errSpy = sinon.spy((): void => void 0)
 
       tmpDB.connect()
-      tmpDB.update(T, { id: 1 }, {
+      tmpDB.update(T, { id: 1 } as any, {
         members: ['1', '2']
       })
       .catch(errSpy)
@@ -1048,11 +1048,8 @@ export default describe('Database Testcase: ', () => {
 
       const execRet1 = yield database.upsert<ProgramSchema>('Program', program)
 
-      yield database.delete<ProgramSchema>('Program', {
-        where: {
-          _id: program._id
-        }
-      })
+      // todo(dingwen): delete 的参数究竟需不需要 where
+      yield database.delete<ProgramSchema>('Program', { _id: program._id })
 
       const execRet2 = yield database.upsert<ProgramSchema>('Program', program)
 
@@ -1164,7 +1161,7 @@ export default describe('Database Testcase: ', () => {
       const moduleCount = 20
 
       const programs = programGen(programCount, moduleCount)
-      const engineerIds = Array.from(new Set(
+      const engineerIds: string[] = Array.from(new Set(
         programs
           .map(p => p.modules)
           .reduce((acc, pre) => acc.concat(pre))
@@ -1173,7 +1170,7 @@ export default describe('Database Testcase: ', () => {
       )
       yield database.upsert('Program', programs)
 
-      const clause = { where: { $in: engineerIds } }
+      const clause = { where: { _id: { $in: engineerIds } } }
       const storedEngineers = yield database.get('Engineer', clause).values()
 
       const execRet = yield database.remove('Module')


### PR DESCRIPTION
原来的定义中，P in keyof T & PredicateMeta<T> 的操作符优先级有误，想
表达的语义是 P in keyof (T & PredicateMeta<T>)（这种写法 ts 不支持），
而实际的语义是好像并非如此，不在 T 或 PredicateMeta 中的属性名不会导致
报错，降低了类型检查的有效性。