### PR TITLE
perf(Mutation): drop object spread operation in patch()

### DIFF
--- a/src/storage/modules/Mutation.ts
+++ b/src/storage/modules/Mutation.ts
@@ -99,7 +99,9 @@ export class Mutation {
   }
 
   patch(patch: Object) {
-    this.params = { ...this.params, ...patch }
+    forEach(patch, (val, key) => {
+      this.params[key] = val
+    })
     return this
   }
 


### PR DESCRIPTION
patch() method on Mutation can be heavily used during large amount of
database upsert operations. Yet it is performing poorly for seemingly
simple operation (updating `this.params`). The object spread seems to
be the culprit.

In this PR, simple "loop + assignment" is used to prevent
unnecessary object creation as in the original implementation.

Note: `Object.assign` is sadly not available for targeting ES5.
Otherwise, it would be an even better choice.