### PR TITLE
fix(tools/version): 令 src/version.ts 文件的更新兼容正式版本之外的版本

### DIFF
--- a/tools/version.ts
+++ b/tools/version.ts
@@ -4,6 +4,6 @@ const version = require('../package.json').version
 
 const filePath = 'src/version.ts'
 
-const replace = fs.readFileSync(filePath, 'utf-8').replace(/[\d\.]+/g, `${version}`)
+const replace = fs.readFileSync(filePath, 'utf-8').replace(/'.*'/g, `'${version}'`)
 
 fs.writeFileSync(filePath, replace)


### PR DESCRIPTION
避免出现如下面这样的问题：

 1. 当前版本 0.10.3-alpha.3-lazyassert
 2. 跑 `npm run version`
 3. src/version 里 export 出来的值变为
 '0.10.3-alpha.3-lazyassert-alpha0.10.3-alpha.3-lazyassert-lazyassert'